### PR TITLE
Add AI chatbot to docs search

### DIFF
--- a/apps/docs/app/api/rag/route.ts
+++ b/apps/docs/app/api/rag/route.ts
@@ -1,0 +1,58 @@
+import { createOpenAI } from '@ai-sdk/openai';
+import { streamText } from 'ai';
+import { neon, neonConfig } from '@neondatabase/serverless';
+
+neonConfig.fetchConnectionCache = true;
+const sql = neon(process.env.DATABASE_URL!);
+
+export const runtime = 'edge';
+
+const openai = createOpenAI({ apiKey: process.env.OPENAI_API_KEY });
+
+async function createEmbedding(text: string) {
+  const res = await fetch('https://api.openai.com/v1/embeddings', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${process.env.OPENAI_API_KEY}`,
+    },
+    body: JSON.stringify({
+      model: 'text-embedding-3-small',
+      input: text,
+    }),
+  });
+  const json = await res.json();
+  return json.data[0].embedding as number[];
+}
+
+export async function POST(req: Request) {
+  const { messages } = await req.json();
+  const question = messages?.at(-1)?.content ?? '';
+
+  const vec = await createEmbedding(question);
+  const vecStr = `[${vec.join(',')}]`;
+
+  const rows = await sql<{ content: string; url: string }>`
+    SELECT e.content, d.url
+    FROM embeddings e
+    JOIN documents d ON e.document_id = d.id
+    ORDER BY e.embedding <-> ${vecStr}::vector
+    LIMIT 3
+  `;
+
+  const context = rows
+    .map((r) => `- ${r.content}\n  ${r.url}`)
+    .join('\n');
+
+  const system = `Answer the question using the documentation context below.\n${context}`;
+
+  const result = streamText({
+    model: openai('gpt-3.5-turbo'),
+    messages: [
+      { role: 'system', content: system },
+      ...messages,
+    ],
+  });
+
+  return result.toDataStreamResponse();
+}

--- a/apps/docs/components/ai/chatbot.tsx
+++ b/apps/docs/components/ai/chatbot.tsx
@@ -13,7 +13,7 @@ import {
 import { Loader2, RefreshCw, Send, ArrowLeft } from 'lucide-react';
 import defaultMdxComponents from 'fumadocs-ui/mdx';
 import { cn } from '@/lib/cn';
-import { buttonVariants } from '../../../../packages/ui/src/components/ui/button';
+import { buttonVariants } from '../ui/button';
 import Link from 'fumadocs-core/link';
 import {
   ScrollArea,
@@ -205,14 +205,18 @@ export default function AIChat({ initialInput, onBack }: AIChatProps) {
       <div className="p-2 bg-fd-secondary/50 rounded-xl">
         <div className="rounded-xl overflow-hidden border shadow-lg bg-fd-popover text-fd-popover-foreground">
           <ChatInput />
-          <div className="flex gap-2 items-center text-fd-muted-foreground px-3 py-1.5">
-            <p className="text-xs flex-1">Powered by OpenAI. Answers may be inaccurate.</p>
+          <div className="flex items-center gap-2 text-fd-muted-foreground px-3 py-1.5">
             {onBack && (
-              <button type="button" className={cn(buttonVariants({ size: 'sm', color: 'ghost' }))} onClick={onBack}>
+              <button
+                type="button"
+                className={cn(buttonVariants({ size: 'sm', color: 'ghost' }))}
+                onClick={onBack}
+              >
                 <ArrowLeft className="size-4" />
                 Back
               </button>
             )}
+            <p className="text-xs ms-auto">Powered by OpenAI. Answers may be inaccurate.</p>
           </div>
         </div>
       </div>

--- a/apps/docs/components/ai/chatbot.tsx
+++ b/apps/docs/components/ai/chatbot.tsx
@@ -1,0 +1,221 @@
+'use client';
+import {
+  createContext,
+  type FormHTMLAttributes,
+  type HTMLAttributes,
+  type ReactNode,
+  type TextareaHTMLAttributes,
+  use,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
+import { Loader2, RefreshCw, Send, ArrowLeft } from 'lucide-react';
+import defaultMdxComponents from 'fumadocs-ui/mdx';
+import { cn } from '@/lib/cn';
+import { buttonVariants } from '../../../../packages/ui/src/components/ui/button';
+import Link from 'fumadocs-core/link';
+import {
+  ScrollArea,
+  ScrollViewport,
+} from 'fumadocs-ui/components/ui/scroll-area';
+import { type Message, useChat, type UseChatHelpers } from '@ai-sdk/react';
+
+const ChatContext = createContext<UseChatHelpers | null>(null);
+function useChatContext() {
+  return use(ChatContext)!;
+}
+
+function ChatActions() {
+  const { messages, status, setMessages, reload } = useChatContext();
+  const isLoading = status === 'streaming';
+  if (messages.length === 0) return null;
+  return (
+    <div className="sticky bottom-0 bg-gradient-to-t from-fd-popover px-3 py-1.5 flex flex-row items-center justify-end gap-2 empty:hidden">
+      {!isLoading && messages.at(-1)?.role === 'assistant' && (
+        <button
+          type="button"
+          className={cn(buttonVariants({ color: 'secondary' }), 'text-fd-muted-foreground rounded-full gap-1.5')}
+          onClick={() => reload()}
+        >
+          <RefreshCw className="size-4" />
+          Retry
+        </button>
+      )}
+      <button
+        type="button"
+        className={cn(buttonVariants({ color: 'secondary' }), 'text-fd-muted-foreground rounded-full')}
+        onClick={() => setMessages([])}
+      >
+        Clear Chat
+      </button>
+    </div>
+  );
+}
+
+function ChatInput(props: FormHTMLAttributes<HTMLFormElement>) {
+  const { status, input, setInput, handleSubmit, stop } = useChatContext();
+  const isLoading = status === 'streaming' || status === 'submitted';
+  const onStart = (e?: React.FormEvent) => {
+    e?.preventDefault();
+    handleSubmit(e);
+  };
+
+  useEffect(() => {
+    if (isLoading) document.getElementById('nd-ai-input')?.focus();
+  }, [isLoading]);
+
+  return (
+    <form
+      {...props}
+      className={cn('flex items-start pe-2 transition-colors', isLoading && 'bg-fd-muted', props.className)}
+      onSubmit={onStart}
+    >
+      <Input
+        value={input}
+        placeholder={isLoading ? 'AI is answering...' : 'Ask AI something'}
+        disabled={status === 'streaming' || status === 'submitted'}
+        onChange={(e) => setInput(e.target.value)}
+        onKeyDown={(event) => {
+          if (!event.shiftKey && event.key === 'Enter') {
+            onStart();
+            event.preventDefault();
+          }
+        }}
+      />
+      {isLoading ? (
+        <button
+          type="button"
+          className={cn(buttonVariants({ color: 'secondary', className: 'rounded-full mt-2 gap-2' }))}
+          onClick={stop}
+        >
+          <Loader2 className="size-4 animate-spin text-fd-muted-foreground" />
+          Abort Answer
+        </button>
+      ) : (
+        <button
+          type="submit"
+          className={cn(buttonVariants({ color: 'ghost', className: 'rounded-full mt-2 p-1.5' }))}
+          disabled={input.length === 0}
+        >
+          <Send className="size-4" />
+        </button>
+      )}
+    </form>
+  );
+}
+
+function List(props: Omit<HTMLAttributes<HTMLDivElement>, 'dir'>) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    if (!containerRef.current) return;
+    const observer = new ResizeObserver(() => {
+      const container = containerRef.current;
+      if (!container) return;
+      container.scrollTo({ top: container.scrollHeight, behavior: 'instant' });
+    });
+    containerRef.current.scrollTop = containerRef.current.scrollHeight - containerRef.current.clientHeight;
+    setTimeout(() => {
+      const element = containerRef.current?.firstElementChild;
+      if (element) observer.observe(element);
+    }, 2000);
+    return () => observer.disconnect();
+  }, []);
+  return (
+    <ScrollArea {...props}>
+      <ScrollViewport ref={containerRef} className="max-h-[calc(100dvh-240px)] *:!min-w-0 *:!flex *:flex-col">
+        {props.children}
+      </ScrollViewport>
+    </ScrollArea>
+  );
+}
+
+function Input(props: TextareaHTMLAttributes<HTMLTextAreaElement>) {
+  const ref = useRef<HTMLDivElement>(null);
+  const shared = cn('col-start-1 row-start-1 max-h-60 min-h-12 p-3');
+  return (
+    <div className="grid flex-1">
+      <textarea
+        id="nd-ai-input"
+        className={cn(shared, 'resize-none bg-transparent placeholder:text-fd-muted-foreground focus-visible:outline-none')}
+        {...props}
+      />
+      <div ref={ref} className={cn(shared, 'break-all invisible')}>{`${props.value?.toString() ?? ''}\n`}</div>
+    </div>
+  );
+}
+
+let processor: any | undefined;
+const map = new Map<string, ReactNode>();
+const roleName: Record<string, string> = { user: 'you', assistant: 'fumadocs' };
+
+function Message({ message }: { message: Message }) {
+  return (
+    <div>
+      <p className={cn('mb-1 text-xs font-medium text-fd-muted-foreground', message.role === 'assistant' && 'text-fd-primary')}>{roleName[message.role] ?? 'unknown'}</p>
+      <div className="prose text-sm">
+        <Markdown text={message.content} />
+      </div>
+    </div>
+  );
+}
+
+function Markdown({ text }: { text: string }) {
+  const [currentText, setCurrentText] = useState<string>();
+  const [rendered, setRendered] = useState<ReactNode>(map.get(text));
+  async function run() {
+    const { createProcessor } = await import('./markdown-processor');
+    processor ??= createProcessor();
+    let result = map.get(text);
+    if (!result) {
+      result = await processor.process(text, { ...defaultMdxComponents, img: undefined }).catch(() => text);
+    }
+    map.set(text, result);
+    setRendered(result);
+  }
+  if (text !== currentText) {
+    setCurrentText(text);
+    void run();
+  }
+  return rendered ?? text;
+}
+
+export interface AIChatProps {
+  initialInput?: string;
+  onBack?: () => void;
+}
+
+export default function AIChat({ initialInput, onBack }: AIChatProps) {
+  const chat = useChat({ id: 'search', api: '/api/rag', streamProtocol: 'data', sendExtraMessageFields: true });
+  useEffect(() => {
+    if (initialInput) chat.setInput(initialInput);
+  }, [initialInput]);
+  return (
+    <ChatContext value={chat}>
+      {chat.messages.length > 0 && (
+        <List className="bg-fd-popover rounded-xl border shadow-lg">
+          <div className="flex flex-col gap-4 p-3 pb-0">
+            {chat.messages.map((item, i) => (
+              <Message key={i} message={item} />
+            ))}
+          </div>
+          <ChatActions />
+        </List>
+      )}
+      <div className="p-2 bg-fd-secondary/50 rounded-xl">
+        <div className="rounded-xl overflow-hidden border shadow-lg bg-fd-popover text-fd-popover-foreground">
+          <ChatInput />
+          <div className="flex gap-2 items-center text-fd-muted-foreground px-3 py-1.5">
+            <p className="text-xs flex-1">Powered by OpenAI. Answers may be inaccurate.</p>
+            {onBack && (
+              <button type="button" className={cn(buttonVariants({ size: 'sm', color: 'ghost' }))} onClick={onBack}>
+                <ArrowLeft className="size-4" />
+                Back
+              </button>
+            )}
+          </div>
+        </div>
+      </div>
+    </ChatContext>
+  );
+}

--- a/apps/docs/components/ai/search.tsx
+++ b/apps/docs/components/ai/search.tsx
@@ -13,7 +13,7 @@ import {
 import { Loader2, RefreshCw, Send, X } from 'lucide-react';
 import defaultMdxComponents from 'fumadocs-ui/mdx';
 import { cn } from '@/lib/cn';
-import { buttonVariants } from '../../../../packages/ui/src/components/ui/button';
+import { buttonVariants } from '../ui/button';
 import type { Processor } from './markdown-processor';
 import Link from 'fumadocs-core/link';
 import {

--- a/apps/docs/components/ai/search.tsx
+++ b/apps/docs/components/ai/search.tsx
@@ -292,7 +292,11 @@ function Markdown({ text }: { text: string }) {
   return rendered ?? text;
 }
 
-export default function AISearch(props: DialogProps) {
+export interface AISearchProps extends DialogProps {
+  initialInput?: string;
+}
+
+export default function AISearch(props: AISearchProps) {
   return (
     <Dialog {...props}>
       {props.children}
@@ -306,16 +310,17 @@ export default function AISearch(props: DialogProps) {
           aria-describedby={undefined}
           className="fixed flex flex-col-reverse gap-3 md:flex-col max-md:top-12 md:bottom-12 left-1/2 z-50 w-[98vw] max-w-[860px] -translate-x-1/2 focus-visible:outline-none data-[state=closed]:animate-fd-fade-out"
         >
-          <Content />
+          <Content initialInput={props.initialInput} />
         </DialogContent>
       </DialogPortal>
     </Dialog>
   );
 }
 
-function Content() {
+function Content({ initialInput }: { initialInput?: string }) {
   const chat = useChat({
     id: 'search',
+    api: '/api/rag',
     streamProtocol: 'data',
     sendExtraMessageFields: true,
     onResponse(response) {
@@ -324,6 +329,10 @@ function Content() {
       }
     },
   });
+
+  useEffect(() => {
+    if (initialInput) chat.setInput(initialInput);
+  }, [initialInput]);
 
   return (
     <ChatContext value={chat}>

--- a/apps/docs/components/search.tsx
+++ b/apps/docs/components/search.tsx
@@ -10,6 +10,7 @@ import {
   SearchDialogIcon,
   SearchDialogInput,
   SearchDialogList,
+  SearchDialogListItem,
   SearchDialogOverlay,
   type SharedProps,
   TagsList,
@@ -17,6 +18,8 @@ import {
 } from 'fumadocs-ui/components/dialog/search';
 import { useDocsSearch } from 'fumadocs-core/search/client';
 import { useState } from 'react';
+import dynamic from 'next/dynamic';
+import { Sparkles } from 'lucide-react';
 import { useMode } from '@/app/layout.client';
 import { useOnChange } from 'fumadocs-core/utils/use-on-change';
 
@@ -25,9 +28,12 @@ const client = new OramaClient({
   api_key: 'oPZjdlFbq5BpR54bV5Vj57RYt83Xosk7',
 });
 
+const AISearch = dynamic(() => import('./ai/search'), { ssr: false });
+
 export default function CustomSearchDialog(props: SharedProps) {
   const mode = useMode();
   const [tag, setTag] = useState<string | undefined>(mode);
+  const [aiOpen, setAiOpen] = useState(false);
   const { search, setSearch, query } = useDocsSearch({
     type: 'orama-cloud',
     client,
@@ -39,12 +45,20 @@ export default function CustomSearchDialog(props: SharedProps) {
   });
 
   return (
-    <SearchDialog
-      search={search}
-      onSearchChange={setSearch}
-      isLoading={query.isLoading}
-      {...props}
-    >
+    <>
+      {aiOpen && (
+        <AISearch
+          open={aiOpen}
+          onOpenChange={setAiOpen}
+          initialInput={search}
+        />
+      )}
+      <SearchDialog
+        search={search}
+        onSearchChange={setSearch}
+        isLoading={query.isLoading}
+        {...props}
+      >
       <SearchDialogOverlay />
       <SearchDialogContent>
         <SearchDialogHeader>
@@ -52,8 +66,38 @@ export default function CustomSearchDialog(props: SharedProps) {
           <SearchDialogInput />
           <SearchDialogClose />
         </SearchDialogHeader>
-        {query.data !== 'empty' && query.data && (
-          <SearchDialogList items={query.data} />
+        {query.data !== 'empty' && (
+          <SearchDialogList
+            items={[
+              ...(query.data || []),
+              ...(search
+                ? [
+                    {
+                      id: '__ai',
+                      type: 'page',
+                      content: `Ask AI about "${search}"`,
+                      url: '#',
+                    } as any,
+                  ]
+                : []),
+            ]}
+            Item={({ item, onClick }) => {
+              if (item.id === '__ai')
+                return (
+                  <button
+                    type="button"
+                    className="flex min-h-10 flex-row items-center gap-2.5 rounded-lg px-2 text-start text-sm"
+                    onClick={() => setAiOpen(true)}
+                  >
+                    <Sparkles className="size-4 text-fd-muted-foreground" />
+                    <p className="w-0 flex-1 truncate">{item.content}</p>
+                  </button>
+                );
+              return (
+                <SearchDialogListItem item={item} onClick={onClick} />
+              );
+            }}
+          />
         )}
         <SearchDialogFooter className="flex flex-row">
           <TagsList tag={tag} onTagChange={setTag} allowClear>
@@ -72,5 +116,6 @@ export default function CustomSearchDialog(props: SharedProps) {
         </SearchDialogFooter>
       </SearchDialogContent>
     </SearchDialog>
+    </>
   );
 }

--- a/apps/docs/components/search.tsx
+++ b/apps/docs/components/search.tsx
@@ -20,6 +20,7 @@ import { useDocsSearch } from 'fumadocs-core/search/client';
 import { useState } from 'react';
 import dynamic from 'next/dynamic';
 import { Sparkles } from 'lucide-react';
+const AIChat = dynamic(() => import('./ai/chatbot'), { ssr: false });
 import { useMode } from '@/app/layout.client';
 import { useOnChange } from 'fumadocs-core/utils/use-on-change';
 
@@ -28,12 +29,10 @@ const client = new OramaClient({
   api_key: 'oPZjdlFbq5BpR54bV5Vj57RYt83Xosk7',
 });
 
-const AISearch = dynamic(() => import('./ai/search'), { ssr: false });
-
 export default function CustomSearchDialog(props: SharedProps) {
   const mode = useMode();
   const [tag, setTag] = useState<string | undefined>(mode);
-  const [aiOpen, setAiOpen] = useState(false);
+  const [chatOpen, setChatOpen] = useState(false);
   const { search, setSearch, query } = useDocsSearch({
     type: 'orama-cloud',
     client,
@@ -45,14 +44,7 @@ export default function CustomSearchDialog(props: SharedProps) {
   });
 
   return (
-    <>
-      {aiOpen && (
-        <AISearch
-          open={aiOpen}
-          onOpenChange={setAiOpen}
-          initialInput={search}
-        />
-      )}
+    <> 
       <SearchDialog
         search={search}
         onSearchChange={setSearch}
@@ -66,38 +58,42 @@ export default function CustomSearchDialog(props: SharedProps) {
           <SearchDialogInput />
           <SearchDialogClose />
         </SearchDialogHeader>
-        {query.data !== 'empty' && (
-          <SearchDialogList
-            items={[
-              ...(query.data || []),
-              ...(search
-                ? [
-                    {
-                      id: '__ai',
-                      type: 'page',
-                      content: `Ask AI about "${search}"`,
-                      url: '#',
-                    } as any,
-                  ]
-                : []),
-            ]}
-            Item={({ item, onClick }) => {
-              if (item.id === '__ai')
+        {chatOpen ? (
+          <AIChat initialInput={search} onBack={() => setChatOpen(false)} />
+        ) : (
+          query.data !== 'empty' && (
+            <SearchDialogList
+              items={[
+                ...(query.data || []),
+                ...(search
+                  ? [
+                      {
+                        id: '__ai',
+                        type: 'page',
+                        content: `Ask AI about "${search}"`,
+                        url: '#',
+                      } as any,
+                    ]
+                  : []),
+              ]}
+              Item={({ item, onClick }) => {
+                if (item.id === '__ai')
+                  return (
+                    <button
+                      type="button"
+                      className="flex min-h-10 flex-row items-center gap-2.5 rounded-lg px-2 text-start text-sm"
+                      onClick={() => setChatOpen(true)}
+                    >
+                      <Sparkles className="size-4 text-fd-muted-foreground" />
+                      <p className="w-0 flex-1 truncate">{item.content}</p>
+                    </button>
+                  );
                 return (
-                  <button
-                    type="button"
-                    className="flex min-h-10 flex-row items-center gap-2.5 rounded-lg px-2 text-start text-sm"
-                    onClick={() => setAiOpen(true)}
-                  >
-                    <Sparkles className="size-4 text-fd-muted-foreground" />
-                    <p className="w-0 flex-1 truncate">{item.content}</p>
-                  </button>
+                  <SearchDialogListItem item={item} onClick={onClick} />
                 );
-              return (
-                <SearchDialogListItem item={item} onClick={onClick} />
-              );
-            }}
-          />
+              }}
+            />
+          )
         )}
         <SearchDialogFooter className="flex flex-row">
           <TagsList tag={tag} onTagChange={setTag} allowClear>

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -53,7 +53,8 @@
     "tailwind-merge": "^3.3.0",
     "twoslash": "^0.3.1",
     "unist-util-visit": "^5.0.0",
-    "zod": "^3.25.56"
+    "zod": "^3.25.56",
+    "@neondatabase/serverless": "^0.6.0"
   },
   "devDependencies": {
     "@fumadocs/cli": "workspace:*",


### PR DESCRIPTION
## Summary
- integrate AI search option in docs search dialog
- open AI chat with current query pre-filled
- support initialInput for the AI search dialog
- implement `/api/rag` endpoint using Postgres embeddings and OpenAI

## Testing
- `pnpm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68459941f9a08325a0e33c5b874de14e